### PR TITLE
Add URL to Rundeck executions in TeamCity

### DIFF
--- a/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeck.kt
+++ b/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeck.kt
@@ -61,7 +61,7 @@ public object RunDeck {
         var offset: Long = 0
         var lastModified: Long = 0
         if (execution.code == 200) {
-            println(ServiceMessage.asString("rundeck", mapOf("text" to "Job ${rundeckOptions.jobId} launched successfully with id ${execution.result}", "status" to "NORMAL")))
+            println(ServiceMessage.asString("rundeck", mapOf("text" to "Job ${rundeckOptions.jobId} launched successfully: ${execution.url}", "status" to "NORMAL")))
             if (rundeckOptions.waitFinish) {
                 while (counter < 1200) {
                     val status = rundeckAPI.jobStatus(execution.result, offset, lastModified)

--- a/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeck.kt
+++ b/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeck.kt
@@ -56,12 +56,12 @@ public object RunDeck {
     private fun run(rundeckOptions: RunDeckOptions): Int {
         val rundeckAPI = RunDeckAPI(rundeckOptions.url, rundeckOptions.authToken)
         val execution = rundeckAPI.executeJob(rundeckOptions.jobId, rundeckOptions.jobOptions, rundeckOptions.filters)
-        println(ServiceMessage.asString("rundeck", mapOf("text" to "Starting RunDeck Job ${rundeckOptions.jobId}", "status" to "NORMAL")))
+        println(ServiceMessage.asString("rundeck", mapOf("text" to "Starting Rundeck job  with Id: ${rundeckOptions.jobId}.", "status" to "NORMAL")))
         var counter: Long = 0
         var offset: Long = 0
         var lastModified: Long = 0
         if (execution.code == 200) {
-            println(ServiceMessage.asString("rundeck", mapOf("text" to "Job ${rundeckOptions.jobId} launched successfully: ${execution.url}", "status" to "NORMAL")))
+            println(ServiceMessage.asString("rundeck", mapOf("text" to "Rundeck job ${rundeckOptions.jobId} launched successfully: ${execution.url}.", "status" to "NORMAL")))
             if (rundeckOptions.waitFinish) {
                 while (counter < 1200) {
                     val status = rundeckAPI.jobStatus(execution.result, offset, lastModified)
@@ -74,7 +74,7 @@ public object RunDeck {
                         }
                     }
                     if (status.code == 200 && status.execCompleted) {
-                        println(ServiceMessage.asString("rundeck", mapOf("text" to "RunDeck Job completed with status ${status.execState}", "status" to "NORMAL")))
+                        println(ServiceMessage.asString("rundeck", mapOf("text" to "Rundeck job completed with status: ${status.execState}.", "status" to "NORMAL")))
                         if (status.execState != "succeeded") {
                             return RUNDECK_FAILED
                         } else {
@@ -86,11 +86,11 @@ public object RunDeck {
                     Thread.sleep(5000)
                 }
             } else {
-                println(ServiceMessage.asString("rundeck", mapOf("text" to "Not waiting for job to finish", "status" to "NORMAL")))
+                println(ServiceMessage.asString("rundeck", mapOf("text" to "Not waiting for job to finish.", "status" to "NORMAL")))
                 return RUNDECK_SUCCEEDED
             }
         }
-        println(ServiceMessage.asString("rundeck", mapOf("text" to "Job launch failed with error ${execution.code}:${execution.result}", "status" to "FAILURE")))
+        println(ServiceMessage.asString("rundeck", mapOf("text" to "Rundeck job failed to launch with error: ${execution.code}:${execution.result}.", "status" to "FAILURE")))
         return RUNDECK_FAILED
     }
 

--- a/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeckAPI.kt
+++ b/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeckAPI.kt
@@ -42,7 +42,7 @@ public class RunDeckAPI(val host: String, val authToken: String) {
             200 -> {
                 val id = response.body().string()
                 val element = FileUtil.parseDocument(StringReader(id), false)
-                return RunDeckExecuteJobResponse(200, element.getChild("execution").getAttribute("id").value)
+                return RunDeckExecuteJobResponse(200, element.getChild("execution").getAttribute("id").value, element.getChild("execution").getAttribute("permalink").value)
             }
             403 -> {
                 return RunDeckExecuteJobResponse(403, "Unauthorized")

--- a/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeckAPI.kt
+++ b/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeckAPI.kt
@@ -45,13 +45,13 @@ public class RunDeckAPI(val host: String, val authToken: String) {
                 return RunDeckExecuteJobResponse(200, element.getChild("execution").getAttribute("id").value, element.getChild("execution").getAttribute("permalink").value)
             }
             403 -> {
-                return RunDeckExecuteJobResponse(403, "Unauthorized")
+                return RunDeckExecuteJobResponse(403, "Unauthorized", "")
             }
             404 -> {
-                return RunDeckExecuteJobResponse(404, "Job not found")
+                return RunDeckExecuteJobResponse(404, "Job not found", "")
             }
             else -> {
-                return RunDeckExecuteJobResponse(response.code(), response.body().string())
+                return RunDeckExecuteJobResponse(response.code(), response.body().string(), "")
             }
         }
     }

--- a/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeckAPI.kt
+++ b/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeckAPI.kt
@@ -42,7 +42,7 @@ public class RunDeckAPI(val host: String, val authToken: String) {
             200 -> {
                 val id = response.body().string()
                 val element = FileUtil.parseDocument(StringReader(id), false)
-                return RunDeckExecuteJobResponse(200, element.getChild("execution").getAttribute("id").value, element.getChild("execution").getAttribute("permalink").value)
+                return RunDeckExecuteJobResponse(200, element.getChild("execution").getAttribute("id").value, element.getChild("execution").getAttribute("href").value)
             }
             403 -> {
                 return RunDeckExecuteJobResponse(403, "Unauthorized", "")

--- a/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeckAPIResponse.kt
+++ b/rundeck-agent/src/main/kotlin/com/hadihariri/teamcity/plugins/rundeck/agent/RunDeckAPIResponse.kt
@@ -5,7 +5,10 @@ import java.util.*
 /**
  * Created by hadihariri on 05/10/15.
  */
-data class RunDeckExecuteJobResponse(val code: Int, val result: String)
+data class RunDeckExecuteJobResponse(
+        val code: Int,
+        val result: String, 
+        val url: String)
 
 data class RunDeckJobStatusResponse(
         val code: Int,
@@ -30,5 +33,3 @@ data class RunDeckOptions(
         val jobOptions: String,
         val filters: String
 )
-
-


### PR DESCRIPTION
JIRA: https://appneta.atlassian.net/browse/SRE-2478

Updates the teamcity-rundeck plugin to add in returning the url field for the started rundeck executions. I attempted to raise this to a more visible location using progress service messages ([TC Docs](https://www.jetbrains.com/help/teamcity/service-messages.html#Reporting+Build+Progress)) but those were immediately replaced by the rundeck execution logs unfortunately. 

Either way, the link is now exposed in the execution logs, tested with the tunnel test job as well as replace-nis, working with both the new and old UI.


**Example:**
![image](https://user-images.githubusercontent.com/10457079/110029950-f3890700-7ce9-11eb-968e-1cfdf7c9748f.png)

**TC Job Examples:**
https://tc-test-ha.pm-dev.appneta.com/buildConfiguration/Demo_TestTunnel/1301?buildTab=log&logFilter=debug&focusLine=3&linesState=36.49
https://tc-test-ha.pm-dev.appneta.com/viewLog.html?buildId=1203&tab=buildLog&buildTypeId=Demo_DeployNis&logTab=tree&_focus=36#_state=36 (start progress example)